### PR TITLE
feat(access): add isSuperAdmin utility and restrict access based on roles

### DIFF
--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -1,9 +1,17 @@
 import { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
 
 export const Categories: CollectionConfig = {
   slug: 'categories',
+  access: {
+    read: () => true,
+    update: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user)
+  },
   admin: {
-    useAsTitle: 'name'
+    useAsTitle: 'name',
+    hidden: ({ user }) => !isSuperAdmin(user)
   },
   fields: [
     {

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,16 +1,21 @@
 import type { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
 
 export const Media: CollectionConfig = {
   slug: 'media',
   access: {
     read: () => true,
+    delete: ({ req }) => isSuperAdmin(req.user)
+  },
+  admin: {
+    hidden: ({ user }) => !isSuperAdmin(user)
   },
   fields: [
     {
       name: 'alt',
       type: 'text',
-      required: true,
-    },
+      required: true
+    }
   ],
-  upload: true,
+  upload: true
 }

--- a/src/collections/Orders.ts
+++ b/src/collections/Orders.ts
@@ -1,7 +1,14 @@
 import { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
 
 export const Orders: CollectionConfig = {
   slug: 'orders',
+  access: {
+    read: ({ req }) => isSuperAdmin(req.user),
+    update: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user)
+  },
   admin: {
     useAsTitle: 'name'
   },
@@ -28,7 +35,10 @@ export const Orders: CollectionConfig = {
     {
       name: 'stripeCheckoutSessionId',
       type: 'text',
-      required: true
+      required: true,
+      admin: {
+        description: 'Stripe Checkout Session ID'
+      }
     }
   ]
 }

--- a/src/collections/Products.ts
+++ b/src/collections/Products.ts
@@ -1,7 +1,16 @@
 import type { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
+import { Tenant } from '~/payload-types'
 
 export const Products: CollectionConfig = {
   slug: 'products',
+  access: {
+    create: ({ req }) => {
+      if (isSuperAdmin(req.user)) return true
+      const tenant = req.user?.tenants?.[0]?.tenant as Tenant
+      return Boolean(tenant?.stripeDetailsSubmitted)
+    }
+  },
   admin: {
     useAsTitle: 'name'
   },
@@ -42,6 +51,14 @@ export const Products: CollectionConfig = {
       type: 'select',
       options: ['30-day', '14-day', '7-day', '3-day', '1-day', 'no-refund'],
       defaultValue: '30-day'
+    },
+    {
+      name: 'content',
+      type: 'textarea',
+      admin: {
+        description:
+          'Protected content only visible after purchase. Add product documentation downloadable file, getting started guide and bonus materials. Support markdown formatting.'
+      }
     }
   ]
 }

--- a/src/collections/Reviews.ts
+++ b/src/collections/Reviews.ts
@@ -1,7 +1,14 @@
 import { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
 
 export const Reviews: CollectionConfig = {
   slug: 'reviews',
+  access: {
+    read: ({ req }) => isSuperAdmin(req.user),
+    update: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user)
+  },
   admin: {
     useAsTitle: 'description'
   },

--- a/src/collections/Tags.ts
+++ b/src/collections/Tags.ts
@@ -1,12 +1,17 @@
 import type { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
 
 export const Tags: CollectionConfig = {
   slug: 'tags',
-  admin: {
-    useAsTitle: 'name'
-  },
   access: {
-    read: () => true
+    read: () => true,
+    update: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user)
+  },
+  admin: {
+    useAsTitle: 'name',
+    hidden: ({ user }) => !isSuperAdmin(user)
   },
   fields: [
     {

--- a/src/collections/Tenants.ts
+++ b/src/collections/Tenants.ts
@@ -1,7 +1,12 @@
 import type { CollectionConfig } from 'payload'
+import { isSuperAdmin } from '~/lib/access'
 
 export const Tenants: CollectionConfig = {
   slug: 'tenants',
+  access: {
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user)
+  },
   admin: {
     useAsTitle: 'slug'
   },
@@ -23,7 +28,8 @@ export const Tenants: CollectionConfig = {
       index: true,
       admin: {
         description: `This is the subdomain of the store (e.g. [slug].funroad.com)`
-      }
+      },
+      access: { update: ({ req }) => isSuperAdmin(req.user) }
     },
     {
       name: 'image',
@@ -34,15 +40,20 @@ export const Tenants: CollectionConfig = {
       name: 'stripeAccountId',
       type: 'text',
       required: true,
+      access: {
+        update: ({ req }) => isSuperAdmin(req.user)
+      },
       admin: {
-        readOnly: true
+        description: 'Stripe Account ID associated with your shop'
       }
     },
     {
       name: 'stripeDetailsSubmitted',
       type: 'checkbox',
+      access: {
+        update: ({ req }) => isSuperAdmin(req.user)
+      },
       admin: {
-        readOnly: true,
         description: 'You cannot create products until you submit your Stripe details'
       }
     }

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
 import { tenantsArrayField } from '@payloadcms/plugin-multi-tenant/fields'
+import { isSuperAdmin } from '~/lib/access'
 
 const defaultTenantArrayField = tenantsArrayField({
   tenantsArrayFieldName: 'tenant',
@@ -8,21 +9,33 @@ const defaultTenantArrayField = tenantsArrayField({
   tenantsArrayTenantFieldName: 'tenant',
   arrayFieldAccess: {
     read: () => true,
-    update: () => true,
-    create: () => true
+    update: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user)
   },
   tenantFieldAccess: {
     read: () => true,
-    update: () => true,
-    create: () => true
+    update: ({ req }) => isSuperAdmin(req.user),
+    create: ({ req }) => isSuperAdmin(req.user)
   }
 })
 
 export const Users: CollectionConfig = {
   slug: 'users',
-  admin: {
-    useAsTitle: 'email'
+  access: {
+    read: () => true,
+    update: ({ req, id }) => {
+      if (isSuperAdmin(req.user)) return true
+      if (req.user?.id === id) return true
+      return false
+    },
+    create: ({ req }) => isSuperAdmin(req.user),
+    delete: ({ req }) => isSuperAdmin(req.user)
   },
+  admin: {
+    useAsTitle: 'email',
+    hidden: ({ user }) => !isSuperAdmin(user)
+  },
+
   auth: true,
   fields: [
     {
@@ -39,7 +52,10 @@ export const Users: CollectionConfig = {
       type: 'select',
       defaultValue: ['user'],
       hasMany: true,
-      options: ['super-admin', 'user']
+      options: ['super-admin', 'user'],
+      access: {
+        update: ({ req }) => isSuperAdmin(req.user)
+      }
     },
     {
       ...defaultTenantArrayField,

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,0 +1,6 @@
+import { ClientUser } from 'payload'
+import { User } from '~/payload-types'
+
+export const isSuperAdmin = (user: ClientUser | User | null) => {
+  return Boolean(user?.roles?.includes('super-admin'))
+}

--- a/src/modules/checkout/server/procedures.ts
+++ b/src/modules/checkout/server/procedures.ts
@@ -65,7 +65,7 @@ export const checkoutRouter = createTRPCRouter({
       // throw error if stripe details not submitted
 
       const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = products.docs.map(
-        (product) => ({
+        product => ({
           quantity: 1,
           price_data: {
             unit_amount: product.price * 100, // stripe handles in cents
@@ -134,7 +134,7 @@ export const checkoutRouter = createTRPCRouter({
       return {
         ...data,
         totalPrice: data.docs.reduce((acc, doc) => acc + doc.price, 0),
-        docs: data.docs.map((doc) => ({
+        docs: data.docs.map(doc => ({
           ...doc,
           image: doc.image as Media | null,
           tenant: doc.tenant as Tenant & { image: Media | null }

--- a/src/modules/library/ui/views/product-view.tsx
+++ b/src/modules/library/ui/views/product-view.tsx
@@ -34,7 +34,11 @@ export const ProductView = ({ productId }: ProductViewProps) => {
             </div>
           </div>
           <div className='lg:col-span-5'>
-            <p className='font-medium italic text-muted-foreground'>No spacial content</p>
+            {data.content ? (
+              <p>{data.content}</p>
+            ) : (
+              <p className='font-medium italic text-muted-foreground'>No spacial content</p>
+            )}
           </div>
         </div>
       </section>

--- a/src/modules/products/server/procedures.ts
+++ b/src/modules/products/server/procedures.ts
@@ -22,7 +22,10 @@ export const productsRouter = createTRPCRouter({
 
       const data = await ctx.db.findByID({
         collection: 'products',
-        id: input.id
+        id: input.id,
+        select: {
+          content: false
+        }
       })
 
       let isPurchased = false
@@ -187,7 +190,10 @@ export const productsRouter = createTRPCRouter({
         where,
         sort,
         page: input.cursor,
-        limit: input.limit
+        limit: input.limit,
+        select: {
+          content: false
+        }
       })
 
       const dataWithSummarizedReviews = await Promise.all(

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -175,6 +175,9 @@ export interface Tenant {
    */
   slug: string;
   image?: (string | null) | Media;
+  /**
+   * Stripe Account ID associated with your shop
+   */
   stripeAccountId: string;
   /**
    * You cannot create products until you submit your Stripe details
@@ -234,6 +237,10 @@ export interface Product {
   tag?: (string | Tag)[] | null;
   image?: (string | null) | Media;
   refundPolicy?: ('30-day' | '14-day' | '7-day' | '3-day' | '1-day' | 'no-refund') | null;
+  /**
+   * Protected content only visible after purchase. Add product documentation downloadable file, getting started guide and bonus materials. Support markdown formatting.
+   */
+  content?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -257,6 +264,9 @@ export interface Order {
   name: string;
   user: string | User;
   product: string | Product;
+  /**
+   * Stripe Checkout Session ID
+   */
   stripeCheckoutSessionId: string;
   updatedAt: string;
   createdAt: string;
@@ -428,6 +438,7 @@ export interface ProductsSelect<T extends boolean = true> {
   tag?: T;
   image?: T;
   refundPolicy?: T;
+  content?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -18,6 +18,7 @@ import { Products } from './collections/Products'
 import { Categories } from './collections/Categories'
 
 import { multiTenantPlugin } from '@payloadcms/plugin-multi-tenant'
+import { isSuperAdmin } from './lib/access'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -48,7 +49,7 @@ export default buildConfig({
       tenantsArrayField: {
         includeDefaultField: true
       },
-      userHasAccessToAllTenants: user => Boolean(user?.roles?.includes('super-admin'))
+      userHasAccessToAllTenants: user => isSuperAdmin(user)
     })
     // storage-adapter-placeholder
   ]


### PR DESCRIPTION
Introduce a new utility function `isSuperAdmin` to centralize role-based access control. Update multiple collections and modules to restrict access to super-admin users only. This ensures that sensitive operations and data are only accessible to authorized users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a protected content field to products, visible only after purchase and supporting markdown formatting.
- **Access Control**
  - Introduced role-based access restrictions across collections: only super administrators can create, update, or delete most resources, with some fields and UI elements hidden for non-super admins.
  - Users can now only update their own profiles unless they are super admins.
  - Product creation is allowed for super admins or users whose tenants have completed Stripe setup.
- **UI Improvements**
  - Conditional display of product content based on availability.
  - Admin interface elements and collections are hidden for non-super admin users.
- **Other Changes**
  - Enhanced admin descriptions for certain fields to provide clearer context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->